### PR TITLE
Set mongodb dependency to 2.1.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "proxyquire": "^1.7.4"
   },
   "dependencies": {
-    "fhlog": "^0.12.1",
-    "generic-pool": "^2.3.1",
-    "mongodb": "^2.0.36",
-    "verror": "^1.6.0"
+    "fhlog": "~0.12.1",
+    "generic-pool": "~2.3.1",
+    "mongodb": "2.1.21",
+    "verror": "~1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-utils",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Mongo utilities for simple applications to reduce repetition.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Fix mongodb dependency to 2.1.21 so we don't break stuff when deployed on RHMAP.
  If you deploy an app that uses mongo-utils without mongodb defined in package.json, the mongo version pulled in currently is 2.2.x.

This causes the following error in RHMAP:
"failed to get collection: failed to connect to mongodb: seed list contains no mongos proxies, replicaset connections requires the parameter replicaSet to be supplied in the URI or options object, mongodb://server:port/db?replicaSet=name"

If you prefer, I can specify the mongodb version in package.json, but thought this PR might save someone a headache.
